### PR TITLE
setup.py: remove pip import

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   main:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-# Pip Package Manager
-# ------------------------------------------------------------------------------
-try:
-    import pip
-    import setuptools
-except ImportError:
-    url = "http://pip.readthedocs.org"
-    error = f"pip is not installed, refer to <{url}> for instructions."
-    raise ImportError(error)
+import setuptools
 
 # Pandoc Metadata
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This change removes an unused import of pip from setup.py in order to make the project compatible with default setuptools build via PEP 517 front ends.

If pip is indeed required, this needs to be explicitly specified in a pyproject.toml file as shown below to ensure build systems do not fail unexpectedly.

```toml
[build-system]
requires = ["setuptools", "pip"]
build-backend = "setuptools.build_meta"
```